### PR TITLE
update YOLO export to include opset=13

### DIFF
--- a/model_to_pipeline/steps/step_download_model.py
+++ b/model_to_pipeline/steps/step_download_model.py
@@ -57,7 +57,7 @@ class StepDownloadModel(StepBase):
                 model = ultralytics.YOLO(
                     os.path.splitext(os.path.basename(args.model_path))[0]
                 )
-                model.export(format="onnx")
+                model.export(format="onnx", opset=13, simplify=False, dynamic=False, imgsz=640)
                 logging.info(
                     f"Model {args.model_name} downloaded successfully to {args.model_path}."
                 )


### PR DESCRIPTION
From
model.export(format="onnx")
To
model.export(format="onnx", opset=13, simplify=False, dynamic=False, imgsz=640)

# Pull Request Template

## Summary
Explain the motivation and context for this PR.  
- What problem does it solve?  Resize op with opset 19 causes surgery step to fail (suggest using opset=13) #5
- Which issue does it close (e.g., `Fixes #123`)?  https://github.com/SiMa-ai/tool-model-to-pipeline/issues/5

---

## Type of Change
Please mark the relevant options with an `x`:

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor / code cleanup  
- [ ] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [ ] Unit tests added/updated  
- [x] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [x] Verified with Yocto/SDK build  
- [x] Manual functional tests (describe below)  

---

## Checklist
- [x] Code follows project style guidelines  
- [ ] Comments/documentation updated where needed  
- [ ] New dependencies documented in README or `requirements.txt`  
- [x] Related issues linked in PR description  
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)  

---

## Additional Notes
Add any other relevant details, screenshots, or context here.
This is to apply a fix for /tool-model-to-pipeline/model_to_pipeline/steps/step_download_model.py  
The fix is "yolo export model=yolov8m.pt format=onnx imgsz=640 opset=13 dynamic=False simplify=False nms=False"
